### PR TITLE
Only yell if save() was called

### DIFF
--- a/django_paranoia/sessions.py
+++ b/django_paranoia/sessions.py
@@ -53,10 +53,16 @@ class SessionStore(Base):
         """
         data = self._get_session()
         stash = data.get(DATA_PREFIX, None)
-        if stash is None:
+        if stash is None and (self.modified or
+                              settings.SESSION_SAVE_EVERY_REQUEST):
             # If a subclass overrides save(), this should catch it.
+            # We only check this when we know save() was called.
+            # During automated testing, save() is not typically called.
             raise ValueError('Cannot check data because it was not stashed. '
                              'This typically happens in save()')
+        if not stash:
+            stash = {}
+
         for k in META_KEYS:
             saved = stash.get('meta:%s' % k, '')
             current = request.META.get(k, '')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-paranoia',
-    version='0.1.8.5',
+    version='0.1.8.6',
     description='OWASP detection point reporting for Django',
     long_description=open('README.rst').read(),
     author='Andy McKay',


### PR DESCRIPTION
If a subclass didn't implement save right we want to yell about it but only if
save() was actually called. For example, when running tests save() is not
typically called.
